### PR TITLE
Naprawienie Błędu w lini 74, sprawdzającego czy w sąsiednich polach są miny

### DIFF
--- a/Saper/Program.cs
+++ b/Saper/Program.cs
@@ -71,7 +71,7 @@ class Program
 
 
 
-                        if (count /*??*/ 0)
+                        if (count == 0)
 
                         {
 


### PR DESCRIPTION
Naprawienie linii 74 w kodzie sapera